### PR TITLE
Fix/supprime redondance readme

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,6 +3,8 @@ on:
     push:
         branches:
             - main
+        paths-ignore:
+            - '**/README.md'
 jobs:
     audit:
         runs-on: ubuntu-latest

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -1,5 +1,8 @@
 name: E2E on Chrome
-on: push
+on: 
+    push:
+        paths-ignore:
+            - '**/README.md'
 jobs:
     cypress-run:
         runs-on: ubuntu-20.04

--- a/.github/workflows/e2e-edge.yml
+++ b/.github/workflows/e2e-edge.yml
@@ -3,6 +3,8 @@ on:
     push:
         branches:
             - main
+        paths-ignore:
+            - '**/README.md'
 jobs:
     cypress-run:
         runs-on: windows-latest

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -3,6 +3,8 @@ on:
     push:
         branches:
             - main
+        paths-ignore:
+            - '**/README.md'
 jobs:
     cypress-run:
         runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: Unit tests
-on: push
+on: 
+    push:
+        paths-ignore:
+            - '**/README.md'
 jobs:
     jest:
         runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Nous avons longtemps utilisé [Gatsby](https://www.gatsbyjs.com/) pour gérer [le site du CaenCamp](https://github.com/CaenCamp/new-website). Mais force est de constater que l'utilisation de Gatsby était une porte d'entrée complexe pour des personnes novices et que maintenir les versions du système et des plug-ins une sinécure.
 
-De plus, nous souhaitions ouvrir plus largement ouvrir les contenus du CaenCamp et l'utilisation du markdown était pour cela limitant.
+De plus, nous souhaitions ouvrir plus largement les contenus du CaenCamp et l'utilisation du markdown était pour cela limitant.
 
 Nous avons donc basculé les contenus dans une base de données postgreSQL et les avons exposés publiquement via une [API Rest](https://api.caen.camp/documentation).
 


### PR DESCRIPTION
## Description

Corrige une redondance dans le readme. Ajoute l'exclusion des readme dans la CI. J'ai préféré ne pas exclure tous les fichiers markdown pour l'instant.

## Issue liée

Pas d'issue

## ToDo list

<!--- Vous pouvez ajouter les étapes des choses à réaliser dans votre PR. -->
<!--- Cela rendra les choses plus facile surtout si vous avez besoin d'aide pour mener la PR à bout -->

- [ ] Vérifier l'impact de la conf CI sur les github actions


## Checklist

- [ ] Au besoin, la documentation a-t-elle bien été mise à jours ? (adr, wiki, guide de contribution ...)
- [ ] La PR est testée
- [ ] L'issue associée est référencée dans les commentaires pour la clôturer automatiquement au merge
- [ ] Le label `RFR` a été ajouté indiquant aux autres contributeurs qu'elle est selon vous *mergable*

<!-- Vous pouvez bien évidement ajouter tous les commentaires vous semblant pertinant pour cette PR ! -->
